### PR TITLE
rewrote scale node as a service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(catkin REQUIRED COMPONENTS
   roscpp
   rospy
   std_msgs
+  message_generation
 )
 
 ## System dependencies are found with CMake's conventions
@@ -51,11 +52,10 @@ find_package(catkin REQUIRED COMPONENTS
 # )
 
 ## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Service1.srv
-#   Service2.srv
-# )
+add_service_files(
+  FILES
+  get_scale_weight.srv
+)
 
 ## Generate actions in the 'action' folder
 # add_action_files(
@@ -65,10 +65,10 @@ find_package(catkin REQUIRED COMPONENTS
 # )
 
 ## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   std_msgs
-# )
+generate_messages(
+  DEPENDENCIES
+  std_msgs
+)
 
 ################################################
 ## Declare ROS dynamic reconfigure parameters ##

--- a/launch/boba_bot.launch
+++ b/launch/boba_bot.launch
@@ -1,4 +1,4 @@
 <launch>
-  <node pkg="boba_bot" type="read_scale.py" name="scale"/>
-  <node pkg="boba_bot" type="boba_bot.py" name="boba_bot" launch-prefix="gnome-terminal -x"/>
+  <node pkg="boba_bot" type="read_scale.py" name="scale" output="screen"/>
+  <node pkg="boba_bot" type="boba_bot_node.py" name="boba_bot" launch-prefix="gnome-terminal -x"/>
 </launch>

--- a/package.xml
+++ b/package.xml
@@ -7,7 +7,7 @@
   <!-- One maintainer tag required, multiple allowed, one person per tag --> 
   <!-- Example:  -->
   <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
-  <maintainer email="yizow@todo.todo">yizow</maintainer>
+  <maintainer email="yizow@berkeley.edu">Yizhe Liu</maintainer>
 
 
   <!-- One license tag required, multiple allowed, one license per tag -->
@@ -32,11 +32,11 @@
   <!-- Dependencies can be catkin packages or system dependencies -->
   <!-- Examples: -->
   <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
+    <build_depend>message_generation</build_depend>
   <!-- Use buildtool_depend for build tool packages: -->
   <!--   <buildtool_depend>catkin</buildtool_depend> -->
   <!-- Use run_depend for packages you need at runtime: -->
-  <!--   <run_depend>message_runtime</run_depend> -->
+    <run_depend>message_runtime</run_depend>
   <!-- Use test_depend for packages you need only for testing: -->
   <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>

--- a/src/boba_bot_node.py
+++ b/src/boba_bot_node.py
@@ -18,6 +18,10 @@ class MainLoop(cmd.Cmd):
     """Executes only once, before commands are interpreted.
     """
     rospy.init_node(MAIN_NODE)
+
+    rospy.wait_for_service(SCALE_SERVICE)
+    self.get_weight = rospy.ServiceProxy(SCALE_SERVICE, get_scale_weight)
+
     self.grabbed_cup = None
 
   def do_grab(self, cup):
@@ -38,6 +42,8 @@ class MainLoop(cmd.Cmd):
     """Pours a grabbed cup.
     """
     self.report("pouring")
+    response = self.get_weight()
+    print("weight: {}".format(response.weight.data))
 
   def do_return(self, line):
     """Returns a grabbed cup to its original position.

--- a/srv/get_scale_weight.srv
+++ b/srv/get_scale_weight.srv
@@ -1,0 +1,3 @@
+# No request fields
+---
+std_msgs/Float32 weight


### PR DESCRIPTION
The scale node now responds to service requests for the current weight,
instead of constantly publishing the weights to a topic.
Instead of waiting infinitely long for a scale to be plugged in / turned on, after 10 seconds the scale node will start reporting dummy data. 

Boba_bot now reports the current scale reading when told to pour.

Boba_bot.py has been renamed to boba_bot_node.py to avoid namespace
conflicts with the package name.

The launch file has been updated to direct output from the scale node to
the roslaunch terminal.